### PR TITLE
ansi escape filter for output capture

### DIFF
--- a/core/src/main/scala/tut/AnsiFilterStream.scala
+++ b/core/src/main/scala/tut/AnsiFilterStream.scala
@@ -1,0 +1,72 @@
+package tut
+
+import java.io.{ OutputStream, FilterOutputStream }
+
+// FilterOutputStream that removes ANSI escapes. This should be fairly efficient, I guess, since
+// it's all case switches on constants. Can inline more if needed but it seems fine. For the
+// record, the format is ESC '[' digits (';' digits)* terminal
+case class AnsiFilterStream(os: OutputStream) extends FilterOutputStream(os) {
+
+  case class State(apply: Int => State)
+
+  val S: State = State {
+    case 27 => I0
+    case _  => F
+  }
+
+  val F: State = State(_ => F)
+
+  val T: State = State(_ => T)
+
+  val I0: State = State {
+    case '[' => I1
+    case _   => F
+  }
+
+  val I1: State = State {
+    case '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' 
+             => I2
+    case _   => F 
+  }
+
+  val I2: State = State { 
+    case '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' 
+             => I2
+    case ';' => I1
+    case '@' | 'A' | 'B' | 'C' | 'D' | 'E' | 'F' | 'G' | 'H' | 'I' | 'J' | 'K' | 'L' | 'M' | 'N' | 
+         'O' | 'P' | 'Q' | 'R' | 'S' | 'T' | 'U' | 'V' | 'W' | 'X' | 'Y' | 'Z' | '[' | '\\'| ']' | 
+         '^' | '_' | '`' | 'a' | 'b' | 'c' | 'd' | 'e' | 'f' | 'g' | 'h' | 'i' | 'j' | 'k' | 'l' | 
+         'm' | 'n' | 'o' | 'p' | 'q' | 'r' | 's' | 't' | 'u' | 'v' | 'w' | 'x' | 'y' | 'z' | '{' | 
+         '|' | '}' | '~'
+             => T // end of ANSI escape
+    case _   => F
+  }
+
+  // Strategy is, accumulate values as long as we're in a non-terminal state, then either discard 
+  // them if we reach T (which means we accumulated an ANSI escape sequence) or print them out if 
+  // we reach F. 
+
+  private var stack: List[Int] = Nil
+  private var state: State     = S // Start
+
+  override def write(n: Int): Unit = 
+    state.apply(n) match {
+
+      case F => 
+        stack.foldRight(())((c, _) => super.write(c))
+        super.write(n)
+        stack = Nil
+        state = S
+      
+      case T =>
+        stack = Nil
+        state = S
+
+      case s =>
+        stack = n :: stack
+        state = s
+
+    }
+
+}
+

--- a/core/src/main/scala/tut/Tut.scala
+++ b/core/src/main/scala/tut/Tut.scala
@@ -89,7 +89,8 @@ object TutMain extends SafeApp {
 
   def file(in: File, out: File): IO[TState] =
     IO(new FileOutputStream(out)).using           { f =>
-    IO(new Spigot(f)).using                       { o =>
+    IO(new AnsiFilterStream(f)).using             { a =>
+    IO(new Spigot(a)).using                       { o =>
     IO(new PrintStream(o, true, Encoding)).using  { s =>
     IO(new OutputStreamWriter(s, Encoding)).using { w =>
     IO(new PrintWriter(w)).using                  { p =>
@@ -99,7 +100,7 @@ object TutMain extends SafeApp {
         i  <- newInterpreter(p)
         ts <- tut(in).exec(TState(false, Set(), false, i, p, o)).ensuring(IO(Console.setOut(oo)))
       } yield ts
-    }}}}}
+    }}}}}}
 
   def newInterpreter(pw: PrintWriter): IO[IMain] =
     IO(new IMain(new Settings <| (_.embeddedDefaults[TutMain.type]), pw))

--- a/example/src/main/tut/Test.md
+++ b/example/src/main/tut/Test.md
@@ -43,6 +43,12 @@ but the bindings should exist now.
 (a, b)
 ```
 
+this should have no escapes
+
+```tut
+println("blah " + Console.RED + "hi" + Console.RESET + " eek")
+```
+
 this shouldn't be interpreted at all
 
 ```scala


### PR DESCRIPTION
Strip out ANSI escapes because they look like crap in markdown. Basically this just strips out colors, which seems ok.
