### PR TITLE
invisible mod

### DIFF
--- a/tests/src/sbt-test/tut/test-00-basic/expect.md
+++ b/tests/src/sbt-test/tut/test-00-basic/expect.md
@@ -52,3 +52,10 @@ scala> new Functor[Either[String, ?]]
               new Functor[Either[String, ?]]
                           ^
 ```
+
+Should be hidden
+
+
+
+
+The end

--- a/tests/src/sbt-test/tut/test-00-basic/src/main/tut/test.md
+++ b/tests/src/sbt-test/tut/test-00-basic/src/main/tut/test.md
@@ -39,3 +39,11 @@ Should get an error
 ```tut:nofail
 new Functor[Either[String, ?]]
 ```
+
+Should be hidden
+
+```tut:invisible
+println("hi")
+```
+
+The end


### PR DESCRIPTION
This adds an `invisible` modifier that interprets but does not render a block. Potentially nice for hiding default imports, although for the record this is discouraged because it makes tutorial code un-runnable without secret knowledge.

fixes #25 