### PR TITLE
:fail option and test

### DIFF
--- a/tests/src/sbt-test/tut/test-05-fail/build.sbt
+++ b/tests/src/sbt-test/tut/test-05-fail/build.sbt
@@ -1,0 +1,14 @@
+tutSettings
+
+scalaVersion := sys.props("scala.version")
+
+lazy val check = TaskKey[Unit]("check")
+
+check := {
+  val expected = IO.readLines(file("expect.md"))
+  val actual   = IO.readLines(crossTarget.value / "tut"/ "test.md")
+  if (expected != actual) 
+    error("Output doesn't match expected: \n" + actual.mkString("\n"))
+}
+
+scalacOptions += "-language:higherKinds"

--- a/tests/src/sbt-test/tut/test-05-fail/expect.md
+++ b/tests/src/sbt-test/tut/test-05-fail/expect.md
@@ -1,0 +1,31 @@
+Ok
+
+```scala
+scala> 1 + 2
+res0: Int = 3
+```
+
+Ok
+
+```scala
+scala> object Foo extends scala.util.control.NoStackTrace
+defined object Foo
+scala> throw Foo // to prevent output from having line numbers
+Foo$
+```
+
+Ok
+
+```scala
+scala> woozle
+<console>:9: error: not found: value woozle
+              woozle
+              ^
+```
+
+No good .. doesn't fail.
+
+```scala
+scala> 1 + 1
+res3: Int = 2
+```

--- a/tests/src/sbt-test/tut/test-05-fail/project/plugins.sbt
+++ b/tests/src/sbt-test/tut/test-05-fail/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("org.tpolecat" % "tut-plugin" % sys.props("project.version"))

--- a/tests/src/sbt-test/tut/test-05-fail/src/main/tut/test.md
+++ b/tests/src/sbt-test/tut/test-05-fail/src/main/tut/test.md
@@ -1,0 +1,24 @@
+Ok
+
+```tut
+1 + 2
+```
+
+Ok
+
+```tut:fail
+object Foo extends scala.util.control.NoStackTrace
+throw Foo // to prevent output from having line numbers
+```
+
+Ok
+
+```tut:fail
+woozle
+```
+
+No good .. doesn't fail.
+
+```tut:fail
+1 + 1
+```

--- a/tests/src/sbt-test/tut/test-05-fail/test
+++ b/tests/src/sbt-test/tut/test-05-fail/test
@@ -1,0 +1,2 @@
+-> tut
+> check


### PR DESCRIPTION
This resolves #28 by adding a `fail` option that *requires* the block to throw an exception or fail to compile. The old `nofail` option will be deprecated and scheduled for removal in 0.4.