### PR TITLE
improve whitespace handling

### DIFF
--- a/tests/src/sbt-test/tut/test-00-basic/expect.md
+++ b/tests/src/sbt-test/tut/test-00-basic/expect.md
@@ -58,4 +58,40 @@ Should be hidden
 
 
 
+Expr-interior newlines preserved in normal mode.
+
+```scala
+scala> val a = 1
+a: Int = 1
+
+scala> val b = 2
+b: Int = 2
+
+scala> val c = 3
+c: Int = 3
+
+scala> def foo(n: Int): String = {
+     |   
+     |   // interior space
+     |   "bar"
+     | 
+     | }
+foo: (n: Int)String
+```
+
+All newlines preserved in silent mode.
+
+```scala
+val a = 1
+val b = 2
+val c = 3
+
+def foo(n: Int): String = {
+  
+  // interior space
+  "bar"
+
+}
+```
+
 The end

--- a/tests/src/sbt-test/tut/test-00-basic/src/main/tut/test.md
+++ b/tests/src/sbt-test/tut/test-00-basic/src/main/tut/test.md
@@ -46,4 +46,34 @@ Should be hidden
 println("hi")
 ```
 
+Expr-interior newlines preserved in normal mode.
+
+```tut
+val a = 1
+val b = 2
+val c = 3
+
+def foo(n: Int): String = {
+  
+  // interior space
+  "bar"
+
+}
+```
+
+All newlines preserved in silent mode.
+
+```tut:silent
+val a = 1
+val b = 2
+val c = 3
+
+def foo(n: Int): String = {
+  
+  // interior space
+  "bar"
+
+}
+```
+
 The end


### PR DESCRIPTION
This resolves #31 as follows:
- Leading blank lines prior to a statement are ignored in modes that show REPL output. Blank lines are inserted after evaluation, as is done in the standard REPL.
- In all other cases blank lines are preserved when present and are never introduced. This includes blank lines that appear within a multi-line statement in all modes. Thus in `silent` mode the input and output blocks will be identical.