### PR TITLE
add newline after truncated output

### DIFF
--- a/core/src/main/scala/tut/Tut.scala
+++ b/core/src/main/scala/tut/Tut.scala
@@ -188,7 +188,11 @@ object TutMain extends Zed {
     } yield ()
 
   def success: Tut[Unit] =
-    mod(s => s.copy(needsNL = !s.mods(Silent), partial = ""))
+    for {
+      s <- state
+      _ <- new String(s.spigot.bytes, Encoding).endsWith("...").whenM(out("")) // #29
+      _ <- mod(s => s.copy(needsNL = !s.mods(Silent), partial = ""))
+    } yield ()
 
   def incomplete(s: String): Tut[Unit] =
     mod(a => a.copy(partial = a.partial + "\n" + s, needsNL = false))

--- a/tests/src/sbt-test/tut/test-00-basic/expect.md
+++ b/tests/src/sbt-test/tut/test-00-basic/expect.md
@@ -94,4 +94,11 @@ def foo(n: Int): String = {
 }
 ```
 
+This result is so long that the REPL truncates it to a bunch of `a`s with a `...` at the end.
+
+```scala
+scala> val thing = "a" * 1000
+thing: String = aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa...
+```
+
 The end

--- a/tests/src/sbt-test/tut/test-00-basic/src/main/tut/test.md
+++ b/tests/src/sbt-test/tut/test-00-basic/src/main/tut/test.md
@@ -76,4 +76,10 @@ def foo(n: Int): String = {
 }
 ```
 
+This result is so long that the REPL truncates it to a bunch of `a`s with a `...` at the end.
+
+```tut
+val thing = "a" * 1000
+```
+
 The end


### PR DESCRIPTION
This resolves #29 by checking for truncated output on successful evaluation and adding a newline afterward. Luckily we're already accumulating output in a buffer for error-reporting, so this was essentially a one-liner.