### PR TITLE
Supports :book multi line & expression output

### DIFF
--- a/tests/src/sbt-test/tut/test-01-options/expect.md
+++ b/tests/src/sbt-test/tut/test-01-options/expect.md
@@ -35,3 +35,25 @@ new Functor[Either[String, ?]]
 //               new Functor[Either[String, ?]]
 //                           ^
 ```
+
+Can comment multi-line input:
+
+```scala
+case class Fibble(
+  factor:  Int,
+  snazzle: Boolean
+)
+// defined class Fibble
+```
+
+Can comment multi-expression input:
+
+```scala
+import scala.collection.immutable.List
+// import scala.collection.immutable.List
+
+val y = 2
+// y: Int = 2
+```
+
+The End

--- a/tests/src/sbt-test/tut/test-01-options/src/main/tut/test.md
+++ b/tests/src/sbt-test/tut/test-01-options/src/main/tut/test.md
@@ -21,3 +21,22 @@ Should get commented error:
 ```tut:book:nofail
 new Functor[Either[String, ?]]
 ```
+
+Can comment multi-line input:
+
+```tut:book
+case class Fibble(
+  factor:  Int,
+  snazzle: Boolean
+)
+```
+
+Can comment multi-expression input:
+
+```tut:book
+import scala.collection.immutable.List
+
+val y = 2
+```
+
+The End


### PR DESCRIPTION
I've been in Spigot again. I dunno about this one... I've improved the `:book` support so it can handle multi-line and multi-expression input (see test files). But to do so I'm keeping the whole markdown output in memory.  

The problem this solves is: not starting to comment output until you're sure the REPL input has been seen by Spigot. Otherwise you get:

![essential-slick-3 pdf page 12 of 22 2015-12-01 21-55-37](https://cloud.githubusercontent.com/assets/102661/11540365/4e8a3336-9924-11e5-8d23-52a1953fec64.png)

There may be better ways.

This PR for your consideration and feedback. 

The one particular comment I'd make is that this PR accumulates markdown output even if you're not using `:book`.