### PR TITLE
Update README URLs based on HTTP redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 The current version is **0.4.1** (changelog [here](CHANGELOG.md)) which runs on **Scala 2.10** and **2.11**.
 
-Projects using **tut** include [doobie](https://github.com/tpolecat/doobie) and [cats](https://github.com/non/cats). If you're using it and would like be added to the list, please submit a PR!
+Projects using **tut** include [doobie](https://github.com/tpolecat/doobie) and [cats](https://github.com/typelevel/cats). If you're using it and would like be added to the list, please submit a PR!
 
 **tut** is a [Typelevel](http://typelevel.org/) project. This means we embrace pure, typeful, functional programming, and provide a safe and friendly environment for teaching, learning, and contributing as described in the Typelevel [Code of Conduct](http://typelevel.org/conduct.html).
 


### PR DESCRIPTION
Created with https://github.com/dkhamsing/frankenstein

### GitHub Corrected URLs 
Was | Now 
--- | --- 
https://github.com/non/cats | https://github.com/typelevel/cats 
