### PR TITLE
Add sbt-buildinfo to avoid hardcoded version number in plugin

### DIFF
--- a/plugin/build.sbt
+++ b/plugin/build.sbt
@@ -11,3 +11,7 @@ publishMavenStyle := false
 bintrayPublishSettings
 
 bintrayOrganization in bintray := Some("tpolecat")
+
+enablePlugins(BuildInfoPlugin)
+buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion)
+buildInfoPackage := "tut"

--- a/plugin/src/main/scala/tut/Plugin.scala
+++ b/plugin/src/main/scala/tut/Plugin.scala
@@ -30,7 +30,7 @@ object Plugin extends sbt.Plugin {
   lazy val tutSettings =
     Seq(
       resolvers += "tpolecat" at "http://dl.bintray.com/tpolecat/maven",
-      libraryDependencies += "org.tpolecat" %% "tut-core" % "0.4.2-SNAPSHOT" % "test",
+      libraryDependencies += "org.tpolecat" %% "tut-core" % BuildInfo.version % "test",
       tutSourceDirectory := sourceDirectory.value / "main" / "tut",
       tutTargetDirectory := crossTarget.value / "tut",
       watchSources <++= tutSourceDirectory map { path => (path ** "*.md").get },

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,3 +6,5 @@ resolvers += Resolver.url(
 addSbtPlugin("me.lessis" % "bintray-sbt" % "0.1.1")
 
 libraryDependencies += "org.scala-sbt" % "scripted-plugin" % sbtVersion.value
+
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.6.0")


### PR DESCRIPTION
sbt-buildinfo provides tut version in runtime so that makes our life a bit easier.