### PR TITLE
Update scala-xml version to 1.0.5

### DIFF
--- a/core/build.sbt
+++ b/core/build.sbt
@@ -11,7 +11,7 @@ crossScalaVersions := Seq("2.10.6", scalaVersion.value, "2.12.0-M3")
 libraryDependencies := {
   CrossVersion.partialVersion(scalaVersion.value) match {
     case Some((2, scalaMajor)) if scalaMajor >= 11 =>
-      libraryDependencies.value :+ "org.scala-lang.modules" %% "scala-xml" % "1.0.1"
+      libraryDependencies.value :+ "org.scala-lang.modules" %% "scala-xml" % "1.0.5"
     case _ =>
       libraryDependencies.value
   }


### PR DESCRIPTION
scala-xml 1.0.1 is not released for Scala 2.12.0-M3.
