### PR TITLE
Return files in subdirs from `tut`

### DIFF
--- a/tests/src/sbt-test/tut/test-06-walk/build.sbt
+++ b/tests/src/sbt-test/tut/test-06-walk/build.sbt
@@ -5,12 +5,17 @@ scalaVersion := sys.props("scala.version")
 lazy val check = TaskKey[Unit]("check")
 
 check := {
+  // runs tut command and generates output files as a side effect
+  val tutOutput = tut.value
+  if (!tutOutput.exists(_._2 == "A.md")) error("A.md not in output")
+  if (!tutOutput.exists(_._2 == "B.md")) error("B.md not in output")
+  if (!tutOutput.exists(_._2 == "sub/D.md")) error("sub/D.md not in output")
   val fs = (crossTarget.value / "tut")
   if (!(fs / "A.md").exists) error("A.md doesn't exist")
   if (!(fs / "B.md").exists) error("B.md doesn't exist")
   if (!(fs / "sub" / "D.md").exists) error("sub/D.md doesn't exist")
   val expected = IO.readLines(tutSourceDirectory.value / "sub" / "E.ignore")
   val actual   = IO.readLines(tutTargetDirectory.value / "sub" / "E.ignore")
-  if (expected != actual) 
+  if (expected != actual)
     error("sub/E.ignored wasn't copied properly: \n" + actual.mkString("\n"))
 }

--- a/tests/src/sbt-test/tut/test-06-walk/test
+++ b/tests/src/sbt-test/tut/test-06-walk/test
@@ -1,2 +1,1 @@
-> tut
-> check
+  > check


### PR DESCRIPTION
Fixes #100.

The `tut` command does successfully recurse into subdirectories and
compile nested files. However, the List that it returns doesn't include
files that are within subdirectories. This causes nested files to not be
picked up by sbt-site if you do something like
`site.addMappingsToSiteDir(tut, "tut")`.

This change adds the touched nested files to the output of the command.
Since the result is no longer necessarily a flat directory, we have to
switch from using `File.getName` to a relative path for the file name
part of the (file, filename) tuple. I'm using `toString` on the relative
path which works just fine on my Mac, but I don't know if that could
cause trouble on Windows machines that might use a different path
delimiter.