### PR TITLE
Add markdown extension to tutNameFilter

### DIFF
--- a/plugin/src/main/scala/tut/Plugin.scala
+++ b/plugin/src/main/scala/tut/Plugin.scala
@@ -45,7 +45,7 @@ object Plugin extends sbt.Plugin {
       tutTargetDirectory := crossTarget.value / "tut",
       watchSources <++= tutSourceDirectory map { path => (path ** "*.md").get },
       tutScalacOptions := (scalacOptions in Test).value,
-      tutNameFilter := """.*\.(md|txt|htm|html)""".r,
+      tutNameFilter := """.*\.(md|markdown|txt|htm|html)""".r,
       tutFiles := tutFilesParser,
       tutPluginJars := {
         // no idea if this is the right way to do this


### PR DESCRIPTION
`markdown` is an equivalent & valid alternative to `md`. Figured it made sense to include it in the default regex since both `htm` & `html` are included.