### PR TITLE
Filter "-Ywarn-unused-import" from scalac options

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,3 +20,4 @@ tutPublishLocal := {
 }
 
 resolvers in ThisBuild += Resolver.typesafeIvyRepo("releases")
+

--- a/plugin/src/main/scala/tut/Plugin.scala
+++ b/plugin/src/main/scala/tut/Plugin.scala
@@ -48,7 +48,7 @@ object Plugin extends sbt.Plugin {
       tutTargetDirectory := crossTarget.value / "tut",
       watchSources <++= tutSourceDirectory map { path => (path ** "*.md").get },
       tutScalacOptions := {
-        val testOptions = scalacOptions.in(test).value
+        val testOptions = scalacOptions.in(Test).value
         val unwantedOptions = Set("-Ywarn-unused-import")
         testOptions.filterNot(unwantedOptions)
       },

--- a/plugin/src/main/scala/tut/Plugin.scala
+++ b/plugin/src/main/scala/tut/Plugin.scala
@@ -47,7 +47,11 @@ object Plugin extends sbt.Plugin {
       tutSourceDirectory := sourceDirectory.value / "main" / "tut",
       tutTargetDirectory := crossTarget.value / "tut",
       watchSources <++= tutSourceDirectory map { path => (path ** "*.md").get },
-      tutScalacOptions := (scalacOptions in Test).value,
+      tutScalacOptions := {
+        val testOptions = scalacOptions.in(test).value
+        val unwantedOptions = Set("-Ywarn-unused-import")
+        testOptions.filterNot(unwantedOptions)
+      },
       tutNameFilter := """.*\.(md|markdown|txt|htm|html)""".r,
       tutFiles := tutFilesParser,
       tutPluginJars := {

--- a/tests/src/sbt-test/tut/test-07-unused-imports/build.sbt
+++ b/tests/src/sbt-test/tut/test-07-unused-imports/build.sbt
@@ -1,0 +1,13 @@
+tutSettings
+
+scalaVersion := sys.props("scala.version")
+
+lazy val check = TaskKey[Unit]("check")
+
+check := {
+  val expected = IO.readLines(file("expect.md"))
+  val actual   = IO.readLines(crossTarget.value / "tut"/ "test.md")
+  if (expected != actual)
+    error("Output doesn't match expected: \n" + actual.mkString("\n"))
+}
+scalacOptions ++= Seq("-Xfatal-warnings", "-Ywarn-unused-import", "-feature")

--- a/tests/src/sbt-test/tut/test-07-unused-imports/expect.md
+++ b/tests/src/sbt-test/tut/test-07-unused-imports/expect.md
@@ -1,0 +1,24 @@
+
+Fails because of "-Xfatal-warnings"
+
+```scala
+scala> trait Functor[F[_]]
+<console>:12: warning: higher-kinded type should be enabled
+by making the implicit value scala.language.higherKinds visible.
+This can be achieved by adding the import clause 'import scala.language.higherKinds'
+or by setting the compiler option -language:higherKinds.
+See the Scala docs for value scala.language.higherKinds for a discussion
+why the feature should be explicitly enabled.
+       trait Functor[F[_]]
+                     ^
+error: No warnings can be incurred under -Xfatal-warnings.
+```
+
+Is ok because unused imports warings are disabled during tut
+
+```scala
+scala> import scala.collection.immutable.List
+import scala.collection.immutable.List
+```
+
+The End

--- a/tests/src/sbt-test/tut/test-07-unused-imports/project/plugins.sbt
+++ b/tests/src/sbt-test/tut/test-07-unused-imports/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("org.tpolecat" % "tut-plugin" % sys.props("project.version"))

--- a/tests/src/sbt-test/tut/test-07-unused-imports/src/main/tut/test.md
+++ b/tests/src/sbt-test/tut/test-07-unused-imports/src/main/tut/test.md
@@ -1,0 +1,14 @@
+
+Fails because of "-Xfatal-warnings"
+
+```tut:fail
+trait Functor[F[_]]
+```
+
+Is ok because unused imports warings are disabled during tut
+
+```tut
+import scala.collection.immutable.List
+```
+
+The End

--- a/tests/src/sbt-test/tut/test-07-unused-imports/test
+++ b/tests/src/sbt-test/tut/test-07-unused-imports/test
@@ -1,0 +1,2 @@
+> tut
+> check


### PR DESCRIPTION
Filter "-Ywarn-unused-import" from scalac options since together with "-Xfatal-warnings" (a common combination) the build fails, because the compile doesn't recognize the a possible usage further down in the markdown. See #105