### PR TITLE
Adds new `:evaluated` Modifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ The following modifiers are supported. Note that you can use multiples if you li
 | `:plain`     | Output will not have `scala` syntax highlighting. |
 | `:invisible` | Suppresses all output. This is not recommended since the point of **tut** is to provide code that the user can type in and expect to work. But in rare cases you might want one of these at the bottom of your file to clean up filesystem mess that your code left behind. |
 | `:book`      | Output will be suitable for copy and paste into the REPL. That is, there are no REPL prompts or margins, and output from the REPL is commented. |
+| `:evaluated` | Suppresses REPL prompts and input statement, output only will be the evaluated statement. |
 | `:reset`    | Resets the REPL state prior to evaluating the code block. Use this option with care, as it has no visible indication and can be confusing to readers who are following along in their own REPLs. |
 
 ### Settings

--- a/core/src/main/scala/tut/Tut.scala
+++ b/core/src/main/scala/tut/Tut.scala
@@ -29,6 +29,7 @@ object TutMain extends Zed {
   case object Book      extends Modifier
   case object Plain     extends Modifier
   case object Invisible extends Modifier
+  case object Evaluated extends Modifier
   case object Reset     extends Modifier
 
   object Modifier {
@@ -40,6 +41,7 @@ object TutMain extends Zed {
         case "book"      => Book
         case "plain"     => Plain
         case "invisible" => Invisible
+        case "evaluated" => Evaluated
         case "reset"     => Reset
       }
 
@@ -177,7 +179,7 @@ object TutMain extends Zed {
     if (mods(Invisible)) {
       ""
     } else if (text.startsWith("```tut")) {
-      if (mods(Plain)) "```" else "```scala"
+      if (mods(Plain) || mods(Evaluated)) "```" else "```scala"
     } else {
       text
     }
@@ -211,7 +213,7 @@ object TutMain extends Zed {
   def out(text: String): Tut[Unit] =
     for {
       s <- state
-      _ <- s.mods(Invisible).unlessM(IO { s.pw.println(text); s.pw.flush() }.liftIO[Tut])
+      _ <- (s.mods(Invisible) || s.mods(Evaluated)).unlessM(IO { s.pw.println(text); s.pw.flush() }.liftIO[Tut])
     } yield ()
 
   def success: Tut[Unit] =
@@ -233,7 +235,7 @@ object TutMain extends Zed {
     } yield ()
 
   def prompt(s: TState): String =
-         if (s.mods(Silent) || s.mods(Book)) ""
+    if (s.mods(Silent) || s.mods(Book) || s.mods(Evaluated)) ""
     else if (s.partial.isEmpty) "scala> "
     else                        "     | "
 

--- a/tests/src/sbt-test/tut/test-00-basic/expect.md
+++ b/tests/src/sbt-test/tut/test-00-basic/expect.md
@@ -64,6 +64,12 @@ Should be evaluated
 Hi, I'm an evaluated expression
 ```
 
+Should be evaluated and the result is shown
+
+```
+sum: Int = 4
+```
+
 Expr-interior newlines preserved in normal mode.
 
 ```scala
@@ -83,6 +89,17 @@ scala> def foo(n: Int): String = {
      | 
      | }
 foo: (n: Int)String
+```
+
+Multiple expressions in an :evaluated block are interpreted according to the code block, where the new lines are preserved
+
+```
+a: Int = 4
+b: Int = 6
+bar: (c: Int)Int
+result: Int = 14
+14
+res9: Int = 14
 ```
 
 All newlines preserved in silent mode.

--- a/tests/src/sbt-test/tut/test-00-basic/expect.md
+++ b/tests/src/sbt-test/tut/test-00-basic/expect.md
@@ -58,6 +58,12 @@ Should be hidden
 
 
 
+Should be evaluated
+
+```
+Hi, I'm an evaluated expression
+```
+
 Expr-interior newlines preserved in normal mode.
 
 ```scala

--- a/tests/src/sbt-test/tut/test-00-basic/src/main/tut/test.md
+++ b/tests/src/sbt-test/tut/test-00-basic/src/main/tut/test.md
@@ -52,6 +52,12 @@ Should be evaluated
 println("Hi, I'm an evaluated expression")
 ```
 
+Should be evaluated and the result is shown
+
+```tut:evaluated
+val sum = 2 + 2
+```
+
 Expr-interior newlines preserved in normal mode.
 
 ```tut
@@ -65,6 +71,22 @@ def foo(n: Int): String = {
   "bar"
 
 }
+```
+
+Multiple expressions in an :evaluated block are interpreted according to the code block, where the new lines are preserved
+
+```tut:evaluated
+val a = 2 + 2
+val b = 3 + 3
+
+def bar(c: Int): Int = {
+
+  // interior space
+  a + b + c
+}
+val result = bar(4)
+println(result)
+result
 ```
 
 All newlines preserved in silent mode.

--- a/tests/src/sbt-test/tut/test-00-basic/src/main/tut/test.md
+++ b/tests/src/sbt-test/tut/test-00-basic/src/main/tut/test.md
@@ -46,6 +46,12 @@ Should be hidden
 println("hi")
 ```
 
+Should be evaluated
+
+```tut:evaluated
+println("Hi, I'm an evaluated expression")
+```
+
 Expr-interior newlines preserved in normal mode.
 
 ```tut

--- a/tests/src/sbt-test/tut/test-01-options/expect.md
+++ b/tests/src/sbt-test/tut/test-01-options/expect.md
@@ -36,6 +36,21 @@ new Functor[Either[String, ?]]
 //                    ^
 ```
 
+Evaluated result is hidden when combining :evaluated and :silent modifiers
+
+```
+```
+
+Code block is evaluated and commented when combining :evaluated and :book modifiers
+
+```
+// initialValue: Int = 4
+// list: List[Int] = List(1, 2, 3)
+// sum: Int = 6
+// 6
+// res3: Int = 6
+```
+
 Can comment multi-line input:
 
 ```scala

--- a/tests/src/sbt-test/tut/test-01-options/src/main/tut/test.md
+++ b/tests/src/sbt-test/tut/test-01-options/src/main/tut/test.md
@@ -22,6 +22,22 @@ Should get commented error:
 new Functor[Either[String, ?]]
 ```
 
+Evaluated result is hidden when combining :evaluated and :silent modifiers
+
+```tut:evaluated:silent
+val sum = 2 + 2
+```
+
+Code block is evaluated and commented when combining :evaluated and :book modifiers
+
+```tut:evaluated:book
+val initialValue = 2 + 2
+val list = List(1, 2, 3)
+val sum = list.fold(0)(_ + _)
+println(sum)
+sum
+```
+
 Can comment multi-line input:
 
 ```tut:book


### PR DESCRIPTION
This PR brings an additional `tut:evaluated` modifier in order to be able to post just the evaluated statement as output.

```tut:evaluated
println(1 + 1)
```

will produce:

```
2
```

When this new feature might be useful? For instance, together with the sbt-buildinfo plugin we could:

```tut:evaluated
println(s"""libraryDependencies += "your.organization" %% "artifact" % "${yourpackage.BuildInfo.version}"""")
```

will produce the following output:

```
libraryDependencies += "your.organization" %% "artifact" % "1.2.3"
```

in case that `1.2.3` is the current version for the artifact.

Please, review at your convenience. Thanks!