### PR TITLE
Test fixes & Scala 2.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,9 @@ matrix:
       jdk: oraclejdk8
 
 script:
-  - sbt ++$TRAVIS_SCALA_VERSION core/compile
-  - "if [[ $TEST_SCRIPTED = 1 ]]; then sbt plugin/compile plugin/publishLocal && sbt ++$TRAVIS_SCALA_VERSION core/publishLocal scripted; fi"
+  - sbt ++$TRAVIS_SCALA_VERSION core/compile core/publishLocal
+  - sbt plugin/compile plugin/publishLocal
+  - "if [[ $TEST_SCRIPTED = 1 ]]; then sbt scripted; fi"
 
 #notifications:
 #  webhooks:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,15 +6,10 @@ jdk:
 
 scala:
   - 2.10.6
-  - 2.12.0-M5
-  - 2.12.0-RC1
-  - 2.12.0-RC2
+  - 2.12.0
 
 matrix:
   include:
-    - scala: 2.12.0-M4
-      env: TEST_SCRIPTED=1
-      jdk: oraclejdk8
     - scala: 2.11.8
       env: TEST_SCRIPTED=1
       jdk: oraclejdk8

--- a/core/build.sbt
+++ b/core/build.sbt
@@ -6,7 +6,7 @@ libraryDependencies ++= Seq(
 
 scalaVersion := "2.11.8"
 
-crossScalaVersions := Seq("2.10.6", scalaVersion.value, "2.12.0-M4", "2.12.0-M5", "2.12.0-RC1", "2.12.0-RC2")
+crossScalaVersions := Seq("2.10.6", scalaVersion.value, "2.12.0")
 
 libraryDependencies := {
   CrossVersion.partialVersion(scalaVersion.value) match {

--- a/tests/build.sbt
+++ b/tests/build.sbt
@@ -1,3 +1,10 @@
+val defaultScalaVersion = "2.11.8"
+
+def testScalaVersion(logger: Logger): String = sys.env.get("TRAVIS_SCALA_VERSION").getOrElse {
+  logger.warn(s"scripted tests: falling back to default Scala version $defaultScalaVersion")
+  defaultScalaVersion
+}
+
 scriptedSettings
 
 scriptedLaunchOpts ++= Seq(
@@ -11,9 +18,10 @@ scriptedLaunchOpts ++= Seq(
   "-XX:+CMSClassUnloadingEnabled",
   "-XX:+UseConcMarkSweepGC",
   "-Dproject.version=" + version.value,
-  "-Dscala.version=" + scalaVersion.value
+  "-Dscala.version=" + testScalaVersion(sLog.value)
 )
 
 publishLocal := () // do tutPublishLocal at the top
 
-scalaVersion := "2.11.8"
+// SBT 0.13.x plugin requires 2.10.x
+scalaVersion := "2.10.6"

--- a/tests/src/sbt-test/tut/test-02-plugins/build.sbt
+++ b/tests/src/sbt-test/tut/test-02-plugins/build.sbt
@@ -11,6 +11,6 @@ check := {
     error("Output doesn't match expected: \n" + actual.mkString("\n"))
 }
 
-resolvers += "bintray/non" at "http://dl.bintray.com/non/maven"
+resolvers += Resolver.sonatypeRepo("releases")
 
-addCompilerPlugin("org.spire-math" %% "kind-projector" % "0.8.0")
+addCompilerPlugin("org.spire-math" % "kind-projector" % "0.9.3" cross CrossVersion.binary)


### PR DESCRIPTION
`scripted` now _invokes SBT_ with the correct Scala version (2.10.6) and then uses the user-specified version _inside the tests_.

Travis setup changed such that `scripted` tests are executed for all supported Scala versions.