### PR TITLE
Brings a new :decorate Modifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ The following modifiers are supported. Note that you can use multiples if you li
 | `:invisible` | Suppresses all output. This is not recommended since the point of **tut** is to provide code that the user can type in and expect to work. But in rare cases you might want one of these at the bottom of your file to clean up filesystem mess that your code left behind. |
 | `:book`      | Output will be suitable for copy and paste into the REPL. That is, there are no REPL prompts or margins, and output from the REPL is commented. |
 | `:evaluated` | Suppresses REPL prompts and input statement, output only will be the evaluated statement. |
+| `:decorate(param)` | Decorates the output scala code block with `param`, enclosed in this way: `{: param }`. You might want to add several `decorate` modifiers if you need it. |
 | `:reset`    | Resets the REPL state prior to evaluating the code block. Use this option with care, as it has no visible indication and can be confusing to readers who are following along in their own REPLs. |
 
 ### Settings

--- a/tests/src/sbt-test/tut/test-09-decorate/build.sbt
+++ b/tests/src/sbt-test/tut/test-09-decorate/build.sbt
@@ -1,0 +1,12 @@
+tutSettings
+
+scalaVersion := sys.props("scala.version")
+
+lazy val check = TaskKey[Unit]("check")
+
+check := {
+  val expected = IO.readLines(file("expect.md"))
+  val actual   = IO.readLines(crossTarget.value / "tut"/ "test.md")
+  if (expected != actual) 
+    error("Output doesn't match expected: \n" + actual.mkString("\n"))
+}

--- a/tests/src/sbt-test/tut/test-09-decorate/expect.md
+++ b/tests/src/sbt-test/tut/test-09-decorate/expect.md
@@ -1,0 +1,147 @@
+Foo
+
+```scala
+scala> 1 + 1
+res0: Int = 2
+```
+
+Bar
+
+```scala
+2 + 2
+```
+{: #div-id-1 }
+
+Baz
+
+```scala
+scala> wut
+<console>:13: error: not found: value wut
+       wut
+       ^
+```
+{: #div-id-2 }
+
+Qux
+
+```scala
+qut
+```
+{: #div-id-3 .class1 }
+
+Quux
+
+```
+scala> 42
+res4: Int = 42
+```
+{: #div-id-4 .class1 }
+
+Should get a warning and should decorate the output block
+
+```scala
+scala> class Functor[F[_]]
+warning: there was one feature warning; re-run with -feature for details
+defined class Functor
+```
+{: .class2 }
+
+Should get an error and should decorate the output block
+
+```scala
+scala> new Functor[Either[String, ?]]
+<console>:14: error: not found: type ?
+       new Functor[Either[String, ?]]
+                                  ^
+<console>:14: error: Either[String,<error>] takes no type parameters, expected: one
+       new Functor[Either[String, ?]]
+                   ^
+```
+{: #div-id-5 .class3 }
+
+Should be hidden
+
+
+
+
+Should be evaluated and should decorate the output block
+
+```
+Hi, I'm an evaluated expression
+```
+{: #div-id-3 }
+
+Should be evaluated and the result is shown and should decorate the output block
+
+```
+sum: Int = 4
+```
+{: #div-id-6 }
+
+Expr-interior newlines preserved in normal mode. Also, it should decorate the output block
+
+```scala
+scala> val a = 1
+a: Int = 1
+
+scala> val b = 2
+b: Int = 2
+
+scala> val c = 3
+c: Int = 3
+
+scala> def foo(n: Int): String = {
+     |   
+     |   // interior space
+     |   "bar"
+     | 
+     | }
+foo: (n: Int)String
+```
+{: .exclude }
+
+Multiple expressions in an :evaluated block are interpreted according to the code block, where the new lines are preserved. Additionally, it should decorate the output block.
+
+```
+a: Int = 4
+b: Int = 6
+bar: (c: Int)Int
+result: Int = 14
+14
+res9: Int = 14
+```
+{: #div-id-1 }
+
+All newlines preserved in silent mode and it should decorate the output block.
+
+```scala
+val a = 1
+val b = 2
+val c = 3
+
+def foo(n: Int): String = {
+  
+  // interior space
+  "bar"
+
+}
+```
+{: #div-id-6 }
+
+This result is so long that the REPL truncates it to a bunch of `a`s with a `...` at the end, decorating the output block at the end.
+
+```scala
+scala> val thing = "a" * 1000
+thing: String = aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa...
+```
+{: .exclude }
+
+```scala
+scala> thing
+<console>:13: error: not found: value thing
+       thing
+       ^
+```
+{: #the-end }
+
+The end

--- a/tests/src/sbt-test/tut/test-09-decorate/project/plugins.sbt
+++ b/tests/src/sbt-test/tut/test-09-decorate/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("org.tpolecat" % "tut-plugin" % sys.props("project.version"))

--- a/tests/src/sbt-test/tut/test-09-decorate/src/main/tut/test.md
+++ b/tests/src/sbt-test/tut/test-09-decorate/src/main/tut/test.md
@@ -1,0 +1,117 @@
+Foo
+
+```tut
+1 + 1
+```
+
+Bar
+
+```tut:silent:decorate(#div-id-1)
+2 + 2
+```
+
+Baz
+
+```tut:nofail:decorate(#div-id-2)
+wut
+```
+
+Qux
+
+```tut:silent:nofail:decorate(#div-id-3):decorate(.class1)
+qut
+```
+
+Quux
+
+```tut:decorate(#div-id-4):decorate(.class1):plain
+42
+```
+
+Should get a warning and should decorate the output block
+
+```tut:decorate(.class2)
+class Functor[F[_]]
+```
+
+Should get an error and should decorate the output block
+
+```tut:decorate(#div-id-5):decorate(.class3):nofail
+new Functor[Either[String, ?]]
+```
+
+Should be hidden
+
+```tut:decorate(#div-id-6):decorate(.class1):invisible
+println("hi")
+```
+
+Should be evaluated and should decorate the output block
+
+```tut:decorate(#div-id-3):evaluated
+println("Hi, I'm an evaluated expression")
+```
+
+Should be evaluated and the result is shown and should decorate the output block
+
+```tut:evaluated:decorate(#div-id-6)
+val sum = 2 + 2
+```
+
+Expr-interior newlines preserved in normal mode. Also, it should decorate the output block
+
+```tut:decorate(.exclude)
+val a = 1
+val b = 2
+val c = 3
+
+def foo(n: Int): String = {
+  
+  // interior space
+  "bar"
+
+}
+```
+
+Multiple expressions in an :evaluated block are interpreted according to the code block, where the new lines are preserved. Additionally, it should decorate the output block.
+
+```tut:decorate(#div-id-1):evaluated
+val a = 2 + 2
+val b = 3 + 3
+
+def bar(c: Int): Int = {
+
+  // interior space
+  a + b + c
+}
+val result = bar(4)
+println(result)
+result
+```
+
+All newlines preserved in silent mode and it should decorate the output block.
+
+```tut:decorate(#div-id-6):silent
+val a = 1
+val b = 2
+val c = 3
+
+def foo(n: Int): String = {
+  
+  // interior space
+  "bar"
+
+}
+```
+
+This result is so long that the REPL truncates it to a bunch of `a`s with a `...` at the end, decorating the output block at the end.
+
+```tut:decorate(.exclude)
+val thing = "a" * 1000
+```
+
+```tut:decorate(#the-end):fail:reset
+thing
+```
+
+The end

--- a/tests/src/sbt-test/tut/test-09-decorate/test
+++ b/tests/src/sbt-test/tut/test-09-decorate/test
@@ -1,0 +1,2 @@
+> tut
+> check


### PR DESCRIPTION
This PR adds a new `decorate` modifier, which provides the ability to decorate the compiled blocks with, for example, css styles that can be used by [kramdown converter](https://kramdown.gettalong.org/quickref.html#html-elements).

For instance:

### original file.md
```
```tut:evaluated:decorate(#div-id-1)
val a = 1
val b = a + 2
println(b + "")
```

```
```tut:silent:decorate(#div-id-2):decorate(.class1)
trait DataSource[Int, Long]{
  def name: String
  def fetchOne(id: Int): Option[Long]
  def fetchMany(ids: List[Int]): Map[Int, Long]
}
```

### compiled file.md
```
a: Int = 1
b: Int = 3
3
```
{: #div-id-1 }

```scala
trait DataSource[Int, Long]{
  def name: String
  def fetchOne(id: Int): Option[Long]
  def fetchMany(ids: List[Int]): Map[Int, Long]
}
```
{: #div-id-2 .class1 }

Let me know if this makes sense to you and I can add the _docs_ and also _scripted tests_ ;)
Thanks!