### PR TITLE
Add a Tut configuration.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 organization in ThisBuild := "org.tpolecat"
 
-version in ThisBuild := "0.4.9-SNAPSHOT"
+version in ThisBuild := "0.5.0-SNAPSHOT"
 
 publishArtifact := false
 

--- a/plugin/build.sbt
+++ b/plugin/build.sbt
@@ -6,7 +6,7 @@ sbtPlugin := true
 
 publishMavenStyle := false
 
-//bintrayOrganization in bintray := Some("tpolecat")
+bintrayOrganization in bintray := Some("tpolecat")
 
 enablePlugins(BuildInfoPlugin)
 buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion)

--- a/plugin/build.sbt
+++ b/plugin/build.sbt
@@ -6,7 +6,7 @@ sbtPlugin := true
 
 publishMavenStyle := false
 
-bintrayOrganization in bintray := Some("tpolecat")
+//bintrayOrganization in bintray := Some("tpolecat")
 
 enablePlugins(BuildInfoPlugin)
 buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion)

--- a/plugin/src/main/scala/tut/Plugin.scala
+++ b/plugin/src/main/scala/tut/Plugin.scala
@@ -78,7 +78,7 @@ object Plugin extends sbt.Plugin {
         override def accept(name: String): Boolean = tutNameFilter.value.pattern.matcher(name).matches()
       }).get,
       tutFiles := tutFilesParser,
-      scalacOptions in Tut := (scalacOptions in (Compile, console)).value.filterNot(unsafeOptions),
+      scalacOptions in Tut := (scalacOptions in (Compile, console)).value,
       tutPluginJars := {
         // no idea if this is the right way to do this
         val deps = (libraryDependencies in Tut).value.filter(_.configurations.fold(false)(_.startsWith("plugin->")))

--- a/tests/src/sbt-test/tut/test-01-options/build.sbt
+++ b/tests/src/sbt-test/tut/test-01-options/build.sbt
@@ -7,8 +7,9 @@ lazy val check = TaskKey[Unit]("check")
 check := {
   val expected = IO.readLines(file("expect.md"))
   val actual   = IO.readLines(crossTarget.value / "tut"/ "test.md")
-  if (expected != actual) 
+  if (expected != actual)
     error("Output doesn't match expected: \n" + actual.mkString("\n"))
 }
 
-scalacOptions += "-language:higherKinds"
+scalacOptions ++= Seq("-language:higherKinds", "-Xfatal-warnings")
+scalacOptions in Tut += "-language:existentials"

--- a/tests/src/sbt-test/tut/test-01-options/expect.md
+++ b/tests/src/sbt-test/tut/test-01-options/expect.md
@@ -71,4 +71,11 @@ val y = 2
 // y: Int = 2
 ```
 
+Should not fail the build:
+
+```scala
+case class A(c: Class[_])
+// defined class A
+```
+
 The End

--- a/tests/src/sbt-test/tut/test-01-options/src/main/tut/test.md
+++ b/tests/src/sbt-test/tut/test-01-options/src/main/tut/test.md
@@ -55,4 +55,10 @@ import scala.collection.immutable.List
 val y = 2
 ```
 
+Should not fail the build:
+
+```tut:book
+case class A(c: Class[_])
+```
+
 The End

--- a/tests/src/sbt-test/tut/test-03-config/build.sbt
+++ b/tests/src/sbt-test/tut/test-03-config/build.sbt
@@ -10,8 +10,8 @@ check := {
   val ccp = (managedClasspath in Compile).value
   if (ccp.exists(_.data.getName.contains("tut-core")))
     error("Compile classpath contains tut-core.")
-  // verify that the test classpath *does* contain tut
-  val tcp = (managedClasspath in Test).value
+  // verify that the tut classpath *does* contain tut
+  val tcp = (managedClasspath in Tut).value
   if (!tcp.exists(_.data.getName.contains("tut-core")))
-    error("Test classpath doesn't contain tut-core.")
+    error("Tut classpath doesn't contain tut-core.")
 }

--- a/tests/src/sbt-test/tut/test-07-unused-imports/build.sbt
+++ b/tests/src/sbt-test/tut/test-07-unused-imports/build.sbt
@@ -11,3 +11,4 @@ check := {
     error("Output doesn't match expected: \n" + actual.mkString("\n"))
 }
 scalacOptions ++= Seq("-Xfatal-warnings", "-Ywarn-unused-import", "-feature")
+(scalacOptions in (Compile, console)) := scalacOptions.value.filterNot(Set("-Ywarn-unused-import"))


### PR DESCRIPTION
This includes a few breaking changes:
* `tutScalacOptions` is replaced by `(scalacOptions in Tut)`
* the `Test` dependencies are no longer on the CLASSPATH
* `-Ywarn-unused-imports` is not filtered out anymore (as discussed on gitter with @tpolecat )

Other, non-breaking behavioural changes:
* `(scalacOptions in Tut)` inherit from `(scalacOptions in (Compile, console))`
* it's now possible to set dependencies specific to tut with the `% "tut"` modifier

At @tpolecat 's suggestion, I've not modified the `README.md` as part of the pull request. The only changes I can think of are in the _Settings_ section:

> | Setting | Explanation | Default Value |
> |---------|-------------|---------------|
> | `tutSourceDirectory` | Location of **tut** source files. | `(sourceDirectory.value in Compile) / "tut"` |
> | `tutNameFilter`      | Regex specifying files that should be interpreted. | Names ending in `.md` `.txt` `.htm` `.html` |
> | `tutTargetDirectory` | Destination for **tut** output. | `crossTarget.value / "tut"` |
> | `(scalacOptions in Tut)`   | Compiler options that will be passed to the **tut** REPL. | Same as `(Compile, console)` configuration. |
> | `tutPluginJars`      | List of compiler plugin jarfiles to be passed to the **tut** REPL. | Same as `Compile` configuration. |

I would also add the following:

> It's possible to add tut specific dependencies through the `% "tut"` modifier.
> For example:
> ```scala
> libraryDependencies += "org.scalacheck" %% "scalacheck" % "1.13.5" % "tut"
> ```

Finally, if this is merged, I would mention the breaking change (and simple fixes) in the next release notes. Happy to write that part of them if you want me to.