### PR TITLE
Add caching instructions to travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,15 @@
 sudo: false
 language: scala
 
+cache:
+  directories:
+    - $HOME/.ivy2/cache
+    - $HOME/.sbt/boot/
+before_cache:
+  # Tricks to avoid unnecessary cache updates
+  - find $HOME/.ivy2 -name "ivydata-*.properties" -delete
+  - find $HOME/.sbt -name "*.lock" -delete
+
 jdk:
   - oraclejdk8
 


### PR DESCRIPTION
This PR adds dependency caching instructions to travis, and *should* speed builds up.

It turns out, however, that since the build process of Tut includes publishing artifacts locally, the gain isn't as massive as it can be with other, simpler projects. Still a net gain (went from 14:16 to 11:51 in my tests), but maybe not worth the hassle. I'll let you be the judge.
