### PR TITLE
Fix -Ywarn-unused-import line in migration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ This setting does not exist anymore, but you can replace it with `(scalacOptions
 Tut does not filter out `-Ywarn-unused-imports` from its `scalacOptions` anymore. If you need to re-enable that behaviour, simply add:
 
 ```scala
-scalacOptions in Tut := scalacOptions.value.filterNot(Set("-Ywarn-unused-import"))
+scalacOptions in Tut := (scalacOptions in Tut).value.filterNot(Set("-Ywarn-unused-import"))
 ```
 
 ##### Missing dependencies


### PR DESCRIPTION
If we make `scalacOptions in Tut` depend on `scalacOptions` directly as before, compiler plugin options added by `tut` are overwritten.
