### PR TITLE
Scala 2.13.0-M1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,9 @@ matrix:
     - scala: 2.12.3
       env: TEST_SCRIPTED=0
       jdk: oraclejdk8
+    - scala: 2.13.0-M1
+      env: TEST_SCRIPTED=0
+      jdk: oraclejdk8
 
 script:
   - sbt ++$TRAVIS_SCALA_VERSION core/compile core/publishLocal

--- a/core/build.sbt
+++ b/core/build.sbt
@@ -6,7 +6,7 @@ libraryDependencies ++= Seq(
 
 scalaVersion := "2.12.3"
 
-crossScalaVersions := Seq("2.11.11", "2.12.3")
+crossScalaVersions := Seq("2.11.11", "2.12.3", "2.13.0-M1")
 
 libraryDependencies += "org.scala-lang.modules" %% "scala-xml" % "1.0.5"
 


### PR DESCRIPTION
(Upgrading to M2 doesn't work yet because sbt's compiler bridge is incompatible, so only M1 for now.)

Forward-port of #168.