### PR TITLE
Build tut-core for Scala 2.10 again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,9 @@ before_cache:
 
 matrix:
   include:
+    - scala: 2.10.6
+      env: TEST_SCRIPTED=0
+      jdk: oraclejdk8
     - scala: 2.11.11
       env: TEST_SCRIPTED=1
       jdk: oraclejdk8

--- a/core/build.sbt
+++ b/core/build.sbt
@@ -11,7 +11,7 @@ crossScalaVersions := Seq("2.10.6", "2.11.11", "2.12.3", "2.13.0-M1")
 libraryDependencies := {
   CrossVersion.partialVersion(scalaVersion.value) match {
     case Some((2, scalaMajor)) if scalaMajor >= 11 =>
-      libraryDependencies.value :+ "org.scala-lang.modules" %% "scala-xml" % "1.0.5"
+      libraryDependencies.value :+ "org.scala-lang.modules" %% "scala-xml" % "1.0.6"
     case _ =>
       libraryDependencies.value
   }

--- a/core/build.sbt
+++ b/core/build.sbt
@@ -6,9 +6,16 @@ libraryDependencies ++= Seq(
 
 scalaVersion := "2.12.3"
 
-crossScalaVersions := Seq("2.11.11", "2.12.3", "2.13.0-M1")
+crossScalaVersions := Seq("2.10.6", "2.11.11", "2.12.3", "2.13.0-M1")
 
-libraryDependencies += "org.scala-lang.modules" %% "scala-xml" % "1.0.5"
+libraryDependencies := {
+  CrossVersion.partialVersion(scalaVersion.value) match {
+    case Some((2, scalaMajor)) if scalaMajor >= 11 =>
+      libraryDependencies.value :+ "org.scala-lang.modules" %% "scala-xml" % "1.0.5"
+    case _ =>
+      libraryDependencies.value
+  }
+}
 
 // scripted-plugin is enabled by default, in particular in this non-sbt subproject
 // this means that switching to 2.11.11 will result in non-existent dependencies


### PR DESCRIPTION
While trying to upgrade refined to sbt 1.0.0 the 2.10 build failed because tut-core 0.6.0 is not available for 2.10:
```
[error] sbt.librarymanagement.ResolveException: unresolved dependency:
org.tpolecat#tut-core_2.10;0.6.0: not found
```
It would nice if upgrading to sbt 1.0.0 and tut 0.6.0 would not mean dropping support for 2.10 in downstream projects or making anyone's build more complicated.

So this commit reverts the parts of #175 that dropped 2.10 support from tut-core.
/cc @larsrh 

