### PR TITLE
Docs: scalacOptions for unused imports

### DIFF
--- a/modules/docs/src/main/tut/faq.md
+++ b/modules/docs/src/main/tut/faq.md
@@ -12,7 +12,7 @@ position: 6
 Tut does not filter out `-Ywarn-unused-imports` from its `scalacOptions` anymore. If you need to re-enable that behaviour, simply add:
 
 ```scala
-scalacOptions in Tut -= "-Ywarn-unused-import"
+scalacOptions in Tut --= Seq("-Ywarn-unused-import", "-Ywarn-unused:imports")
 ```
 
 #### I have missing dependencies!


### PR DESCRIPTION
I had an issue where I had a bunch of warnings when running tut with
the Tpolecat's scalaOptions! I took the options from:
https://tpolecat.github.io/2017/04/25/scalac-flags.html

Fortunately, in the FAQ, I could find a way to work around that. But
the flag for unused import in the FAQ is different from the one I had
in my options: `-Ywarn-unused-import` vs `-Ywarn-unused:imports`

It took me way too long to figure that out, so here it is for others like
me.