### PR TITLE
Fix auto-completion for tutOnly

### DIFF
--- a/modules/plugin/src/main/scala/tut/TutPlugin.scala
+++ b/modules/plugin/src/main/scala/tut/TutPlugin.scala
@@ -131,12 +131,11 @@ object TutPlugin extends AutoPlugin {
   def flatten(f: File): List[File] =
     f :: (if (f.isDirectory) f.listFiles.toList.flatMap(flatten) else Nil)
 
-  val tutFilesParser: Def.Initialize[State => Parser[File]] = Def.setting { (state: State) =>
-    val extracted = Project.extract(state)
-    val dir     = extracted.getOpt(tutSourceDirectory)
-    val files   = dir.fold(List.empty[File])(d => safeListFiles(d, recurse = true))
-    val parsers = dir.fold(List.empty[Parser[File]])(dir => files.map(f => literal(dir.toURI.relativize(f.toURI).getPath).map(_ => f)))
-    val folded  = parsers.foldRight[Parser[File]](failure("<no input files>"))(_ | _)
+  val tutFilesParser: Def.Initialize[Parser[File]] = Def.setting {
+    val dir     = tutSourceDirectory.value
+    val files   = safeListFiles(dir, recurse = true)
+    val parsers = files.map(f => literal(dir.toURI.relativize(f.toURI).getPath).map(_ => f))
+    val folded  = parsers.foldRight[Parser[File]](failure(s"<no input files>"))(_ | _)
     token(Space ~> folded)
   }
 


### PR DESCRIPTION
This fixes auto-completion for `tutOnly` at least for Cats and http4s
(the two projects I spot-checked the result on). I'm hoping that it
doesn't mess anything up for other projects that might have different
builds, but I don't know what I'm doing so it probably does.

I can't really explain why this fixes anything. My hypothesis is that
the previous approach didn't tell SBT that this setting initialization
depended on tutSourceDirectory first being initialized. However, I tried
to follow the code and reason about it and kept getting stuck at opaque
macro definitions, so I gave up on actually understanding. Merge at your
own risk :|