### PR TITLE
Scala 2.13.0-RC2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ matrix:
     - scala: 2.12.7
       env: TEST_SCRIPTED=0
       jdk: oraclejdk8
-    - scala: 2.13.0-RC1
+    - scala: 2.13.0-RC2
       env: TEST_SCRIPTED=0
       jdk: oraclejdk8
 

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ import microsites._
 lazy val `2.10` = "2.10.6"
 lazy val `2.12` = "2.12.7"
 lazy val `2.11` = "2.11.12"
-lazy val `2.13` = "2.13.0-RC1"
+lazy val `2.13` = "2.13.0-RC2"
 
 lazy val commonSettings =
   Seq(


### PR DESCRIPTION
I propose releasing the 2.13.0-RC2 core module under the same version number as the RC1 module (0.6.11), for two reasons:

– there aren't any code changes
– people don't need to bump their sbt plugin