### PR TITLE
Use HTTPS For Tpolecat Bintray Maven

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,16 +14,16 @@ matrix:
   include:
     - scala: 2.10.6
       env: TEST_SCRIPTED=0
-      jdk: oraclejdk8
+      jdk: openjdk8
     - scala: 2.11.12
       env: TEST_SCRIPTED=1
-      jdk: oraclejdk8
+      jdk: openjdk8
     - scala: 2.12.7
       env: TEST_SCRIPTED=0
-      jdk: oraclejdk8
+      jdk: openjdk8
     - scala: 2.13.0
       env: TEST_SCRIPTED=0
-      jdk: oraclejdk8
+      jdk: openjdk8
 
 script:
   - sbt ++$TRAVIS_SCALA_VERSION core/compile core/publishLocal

--- a/modules/plugin/src/main/scala/tut/TutPlugin.scala
+++ b/modules/plugin/src/main/scala/tut/TutPlugin.scala
@@ -36,7 +36,7 @@ object TutPlugin extends AutoPlugin {
   override lazy val projectSettings =
     inConfig(Tut)(Defaults.configSettings) ++
     Seq(
-      resolvers += "tpolecat" at "http://dl.bintray.com/tpolecat/maven",
+      resolvers += "tpolecat" at "https://dl.bintray.com/tpolecat/maven",
       libraryDependencies += "org.tpolecat" %% "tut-core" % BuildInfo.version % Tut,
       ivyConfigurations += Tut,
       tutSourceDirectory := (sourceDirectory in Compile).value / "tut",


### PR DESCRIPTION
Hi,

Firstly, thanks for the great library!

This should remove the following sbt warnings after switching to 1.3.0:

```
[warn] insecure HTTP request is deprecated 'http://dl.bintray.com/tpolecat/maven'; switch to HTTPS or opt-in as ("tpolecat" at "http://dl.bintray.com/tpolecat/maven").withAllowInsecureProtocol(true)
[warn] insecure HTTP request is deprecated 'http://dl.bintray.com/tpolecat/maven'; switch to HTTPS or opt-in as ("tpolecat" at "http://dl.bintray.com/tpolecat/maven").withAllowInsecureProtocol(true)
[warn] insecure HTTP request is deprecated 'http://dl.bintray.com/tpolecat/maven'; switch to HTTPS or opt-in as ("tpolecat" at "http://dl.bintray.com/tpolecat/maven").withAllowInsecureProtocol(true)
```


https://dl.bintray.com/tpolecat/maven/ resolves correctly, so ideally http should no longer be needed.

Please let me know if you want any additional changes.