### PR TITLE
use 'https' for resolvers

### DIFF
--- a/modules/plugin/src/main/scala/tut/TutPlugin.scala
+++ b/modules/plugin/src/main/scala/tut/TutPlugin.scala
@@ -36,7 +36,7 @@ object TutPlugin extends AutoPlugin {
   override lazy val projectSettings =
     inConfig(Tut)(Defaults.configSettings) ++
     Seq(
-      resolvers += "tpolecat" at "http://dl.bintray.com/tpolecat/maven",
+      resolvers += "tpolecat" at "https://dl.bintray.com/tpolecat/maven",
       libraryDependencies += "org.tpolecat" %% "tut-core" % BuildInfo.version % Tut,
       ivyConfigurations += Tut,
       tutSourceDirectory := (sourceDirectory in Compile).value / "tut",


### PR DESCRIPTION
I'm getting following warning in scala-pet-store project:
```
[warn] insecure HTTP request is deprecated 'http://dl.bintray.com/tpolecat/maven'; switch to HTTPS or opt-in as ("tpolecat" at "http://dl.bintray.com/tpolecat/maven").withAllowInsecureProtocol(true)
```
I hope this PR will fix it. Maybe requires new release after this fix.