### PR TITLE
implement :paste 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,13 +12,13 @@ before_cache:
 
 matrix:
   include:
-    - scala: 2.10.6
+    - scala: 2.10.7
       env: TEST_SCRIPTED=0
       jdk: openjdk8
     - scala: 2.11.12
       env: TEST_SCRIPTED=1
       jdk: openjdk8
-    - scala: 2.12.7
+    - scala: 2.12.10
       env: TEST_SCRIPTED=0
       jdk: openjdk8
     - scala: 2.13.0

--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,8 @@
 import ReleaseTransformations._
 import microsites._
 
-lazy val `2.10` = "2.10.6"
-lazy val `2.12` = "2.12.7"
+lazy val `2.10` = "2.10.7"
+lazy val `2.12` = "2.12.10"
 lazy val `2.11` = "2.11.12"
 lazy val `2.13` = "2.13.0"
 

--- a/build.sbt
+++ b/build.sbt
@@ -116,6 +116,7 @@ lazy val plugin = project
     scalaVersion := `2.12`,
     sbtPlugin := true,
     publishMavenStyle := false,
+    dependencyOverrides += "org.scala-sbt" % "sbt" % "1.2.8",
   )
   .enablePlugins(BuildInfoPlugin)
   .settings(

--- a/modules/core/src/main/scala/tut/FileIO.scala
+++ b/modules/core/src/main/scala/tut/FileIO.scala
@@ -51,7 +51,7 @@ object FileIO extends IMainPlatform /* scala version-specific */ {
     IO(new PrintWriter(streamWriter)).using                 { printWriter =>
       (for {
         interp <- newInterpreter(printWriter, iMainSettings(opts))
-        state  =  TutState(false, Set(), false, interp, printWriter, filterSpigot, "", false, in, opts)
+        state  =  TutState(false, Set(), false, interp, printWriter, filterSpigot, "", false, in, opts, Vector.empty)
         endSt  <- Tut.file(in).exec(state)
       } yield endSt).withOut(printStream)
     }}}}}}

--- a/modules/core/src/main/scala/tut/Modifier.scala
+++ b/modules/core/src/main/scala/tut/Modifier.scala
@@ -14,6 +14,7 @@ final case object Evaluated                     extends Modifier
 final case class  Decorate(decoration: String)  extends Modifier
 final case object Passthrough                   extends Modifier
 final case object Reset                         extends Modifier
+final case object Paste                         extends Modifier
 
 object Modifier {
   private val DecorateP: Regex = "decorate\\((.*)\\)".r
@@ -29,6 +30,7 @@ object Modifier {
     case DecorateP(decoration)  => Decorate(decoration)
     case "passthrough"          => Passthrough
     case "reset"                => Reset
+    case "paste"                => Paste
   }
 
   def unsafeFromString(s: String): Modifier =

--- a/modules/core/src/main/scala/tut/Tut.scala
+++ b/modules/core/src/main/scala/tut/Tut.scala
@@ -65,7 +65,7 @@ object Tut {
                if (text.trim.isEmpty && s.partial.isEmpty) success
                else IO({
                 if (!s.mods(Paste)) s.imain.interpret(s.partial + "\n" + text)
-                else s.imain.withLabel("<pastie>") { s.imain.interpret(pasteCode) }
+                else s.imain.interpret(pasteCode)
                }).liftIO[Tut] >>= {
                  case Results.Incomplete if nextCloses => error(lineNum, Some("incomplete input in code block, missing brace or paren?"))
                  case Results.Incomplete => incomplete(text)

--- a/modules/core/src/main/scala/tut/TutState.scala
+++ b/modules/core/src/main/scala/tut/TutState.scala
@@ -13,5 +13,6 @@ final case class TutState(
   partial: String,
   err: Boolean,
   in: File,
-  opts: List[String]
+  opts: List[String],
+  paste: Vector[String]
 )

--- a/modules/docs/src/main/tut/modifiers.md
+++ b/modules/docs/src/main/tut/modifiers.md
@@ -37,3 +37,4 @@ The following modifiers are supported. Note that you can use multiples if you li
 | `:passthrough`| Same as `evaluated` but code fences are also removed. Useful for code generating Markdown. |
 | `:decorate(param)` | Decorates the output scala code block with `param`, enclosed in this way: `{: param }`, for use with Kramdown. You can add several `decorate` modifiers if you wish. |
 | `:reset`    | Resets the REPL state prior to evaluating the code block. Use this option with care, as it has no visible indication and can be confusing to readers who are following along in their own REPLs. |
+| `:paste`    | Code in the shed is pasted to the REPL. |

--- a/modules/tests/src/sbt-test/tut/test-00-basic/expect.md
+++ b/modules/tests/src/sbt-test/tut/test-00-basic/expect.md
@@ -131,4 +131,38 @@ scala> thing
        ^
 ```
 
+Pasting.
+
+```scala
+scala> :paste
+// Entering paste mode (ctrl-D to finish)
+trait Show[A] { def show(a: A): String }
+object Show {
+  implicit val intShow: Show[Int] = new Show[Int] { def show(a: Int): String = a.toString }
+}
+
+// Exiting paste mode, now interpreting.
+
+defined trait Show
+defined object Show
+```
+
+Pasting again.
+
+```scala
+scala> :paste
+// Entering paste mode (ctrl-D to finish)
+trait Show2[A] { def show(a: A): String }
+object Show2 {
+  implicit val intShow: Show2[Int] = new Show2[Int] { def show(a: Int): String = a.toString }
+}
+val str = implicitly[Show2[Int]].show(123)
+
+// Exiting paste mode, now interpreting.
+
+defined trait Show2
+defined object Show2
+str: String = 123
+```
+
 The end

--- a/modules/tests/src/sbt-test/tut/test-00-basic/src/main/tut/test.md
+++ b/modules/tests/src/sbt-test/tut/test-00-basic/src/main/tut/test.md
@@ -114,4 +114,23 @@ val thing = "a" * 1000
 thing
 ```
 
+Pasting.
+
+```tut:paste
+trait Show[A] { def show(a: A): String }
+object Show {
+  implicit val intShow: Show[Int] = new Show[Int] { def show(a: Int): String = a.toString }
+}
+```
+
+Pasting again.
+
+```tut:paste
+trait Show2[A] { def show(a: A): String }
+object Show2 {
+  implicit val intShow: Show2[Int] = new Show2[Int] { def show(a: Int): String = a.toString }
+}
+val str = implicitly[Show2[Int]].show(123)
+```
+
 The end

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.7
+sbt.version=1.3.0


### PR DESCRIPTION
Fixes #62

<pre>
```tut:paste
trait Show[A] { def show(a: A): String }
object Show {
  implicit val intShow: Show[Int] = new Show[Int] { def show(a: Int): String = a.toString }
}
```
</pre>

becomes

<pre>
```scala
scala> :paste
// Entering paste mode (ctrl-D to finish)
trait Show[A] { def show(a: A): String }
object Show {
  implicit val intShow: Show[Int] = new Show[Int] { def show(a: Int): String = a.toString }
}

// Exiting paste mode, now interpreting.

defined trait Show
defined object Show
```
</pre>
